### PR TITLE
sepolicy: drop camera whitelist prop from vendor

### DIFF
--- a/common/vendor/property_contexts
+++ b/common/vendor/property_contexts
@@ -1,2 +1,0 @@
-# Aux camera whitelist prop readable to everything
-vendor.camera.aux.packagelist          u:object_r:exported_default_prop:s0


### PR DESCRIPTION
*fixes: host_init_verifier: Unable to serialize property contexts: Duplicate prefix match detected for 'vendor.camera.aux.packagelist'

Change-Id: I7090f21ba3054fc8327450b1e785ccff101d5737